### PR TITLE
Update workflow to use artifact actions v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           packer init ubi8-hardening.pkr.hcl
           packer build -var 'report={"report_to_heimdall":"false"}' .
       - name: Save scan artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: reports/*.json
         if: always()


### PR DESCRIPTION
Changes made
- Updating artifact actions v3 to v4 since v3 will be deprecated 1/30/2025.